### PR TITLE
WIP Suspend-to-idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # stsx
-Stress Testing Tool for S3/S4
+Stress Testing Tool for S0/S3/S4

--- a/stsx
+++ b/stsx
@@ -66,6 +66,7 @@ fi
 
 delay=10
 resume=""
+alternate=0
 simulation="none"
 
 case "x$method" in

--- a/stsx
+++ b/stsx
@@ -45,7 +45,7 @@ watchdog="$2 $3"
 maxnum="$4"
 if [ "x$1" = x ] ; then
   cat 1>&2 <<"EOUSAGE"
-Usage: $0 <s4|s4k|s3|s3k|s4simdev|s4simcore|s3simdev|s3simplatform|s3simcore|s4simcpu> [watchdog port [maxnum]]
+Usage: $0 <s4|s4k|s3|s3k|s0|s0k|s4simdev|s4simcore|s3simdev|s3simplatform|s3simcore|s4simcpu> [watchdog port [maxnum]]
 
 Possible deductions:
 simdev fails                 -> no BIOS issue
@@ -73,6 +73,8 @@ xs4)		resume=70;		;;
 xs4k)		resume=70;		;;
 xs3)		resume=20;		;;
 xs3k)		resume=20;		;;
+xs0)    resume=20;    ;;
+xs0k)   resume=20;    ;;
 xs43)		alternate=1;		method="s4"	resume=70	;;
 xs43k)          alternate=1;      	method="s4"	resume=70	;;
 xs4simdev)	simulation="devices";	delay=5;	;;
@@ -224,6 +226,7 @@ while [ $c -lt $maxnum ] ; do
   xs3)
     #NUM_SECONDS_TO_SLEEP=$resume pm-suspend
     set_alarm $t
+    echo deep >/sys/power/mem_sleep
     if which pm-suspend >/dev/null; then
         pm-suspend
     else
@@ -232,6 +235,21 @@ while [ $c -lt $maxnum ] ; do
     ;;
   xs3k)
     set_alarm $t
+    echo deep >/sys/power/mem_sleep
+    echo mem >/sys/power/state
+    ;;
+  xs0)
+    set_alarm $t
+    echo s2idle >/sys/power/mem_sleep
+    if which pm-suspend >/dev/null; then
+        pm-suspend
+    else
+        systemctl suspend
+    fi
+    ;;
+  xs0k)
+    set_alarm $t
+    echo s2idle >/sys/power/mem_sleep
     echo mem >/sys/power/state
     ;;
   xs4sim*)


### PR DESCRIPTION
This pull-request introduces the method s0 and s0k for testing _suspend-to-idle (s2idle)_ [1] and adds a default value for the variable _alternate_.

[1] https://www.kernel.org/doc/html/v4.15/admin-guide/pm/sleep-states.html#suspend-to-idle